### PR TITLE
Add a new module for poi-3.11 including poi-ooxml-schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .classpath
 .DS_Store
 dependency-reduced-pom.xml
+.idea

--- a/poi-3.11/pom.xml
+++ b/poi-3.11/pom.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+    
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>10</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+    
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.poi</artifactId>
+    <version>3.11</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+    <description>
+        This OSGi bundle wraps poi, poi-contrib, poi-ooxml, poi-ooxml-schemas and poi-scratchpad ${pkgVersion} jar files.
+    </description>
+    
+    <properties>
+        <pkgGroupId>org.apache.poi</pkgGroupId>
+        <pkgArtifactId>poi</pkgArtifactId>
+        <pkgVersion>3.11</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.etsi.uri.x01903*;version=${pkgVersion};-split-package:=merge-first,
+            org.w3.x2000.x09.xmldsig*;version=${pkgVersion};-split-package:=merge-first,
+            org.openxmlformats.schemas*;version=${pkgVersion};-split-package:=merge-first,
+            com.microsoft.schemas.office.x2006*;version=${pkgVersion};-split-package:=merge-first,
+            org.apache.poi
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            com.sun.javadoc;resolution:=optional,
+            com.sun.tools.javadoc;resolution:=optional,
+            junit.framework;resolution:=optional,
+            org.apache.crimson.*;resolution:=optional,
+            org.apache.tools.ant*;resolution:=optional,
+            org.bouncycastle.*;resolution:=optional,
+            org.junit.*;resolution:=optional,
+            org.openxmlformats*;resolution:=optional,
+            repackage;resolution:=optional,
+            schemasMicrosoftCom*;resolution:=optional,
+            *
+        </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+            org.apache.xmlbeans.*;-split-package:=merge-first
+        </servicemix.osgi.private.pkg>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>poi-contrib</artifactId>
+            <version>3.6</version>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>poi-scratchpad</artifactId>
+            <version>${pkgVersion}</version>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>${pkgVersion}</version>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>poi-ooxml-schemas</artifactId>
+            <version>${pkgVersion}</version>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlbeans</groupId>
+            <artifactId>xmlbeans</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>poi-contrib</artifactId>
+            <version>3.6</version>
+            <classifier>sources</classifier>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>poi-scratchpad</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+            <optional>false</optional>
+        </dependency>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+            <optional>false</optional>
+        </dependency>
+
+        <!-- Sources not available -->
+        <!--<dependency>-->
+            <!--<groupId>${pkgGroupId}</groupId>-->
+            <!--<artifactId>poi-ooxml-schemas</artifactId>-->
+            <!--<version>${pkgVersion}</version>-->
+            <!--<classifier>sources</classifier>-->
+            <!--<optional>false</optional>-->
+        <!--</dependency>-->
+        <!--<dependency>-->
+            <!--<groupId>org.apache.xmlbeans</groupId>-->
+            <!--<artifactId>xmlbeans</artifactId>-->
+            <!--<version>2.6.0</version>-->
+            <!--<classifier>sources</classifier>-->
+        <!--</dependency>-->
+
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                    <include>${pkgGroupId}:poi-contrib</include>
+                                    <include>${pkgGroupId}:poi-scratchpad</include>
+                                    <include>${pkgGroupId}:poi-ooxml</include>
+                                    <include>${pkgGroupId}:poi-ooxml-schemas</include>
+                                    <include>dom4j:dom4j</include>
+                                    <include>org.apache.xmlbeans:xmlbeans</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>${pkgGroupId}:poi-contrib</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>${pkgGroupId}:poi-scratchpad</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>${pkgGroupId}:poi-ooxml</artifact>
+                                    <includes>
+                                        <include>**/*.xml</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/poi-3.11/src/main/resources/OSGI-INF/bundle.info
+++ b/poi-3.11/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,38 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URLs:
+        \u001B[33mmvn:${pkgGroupId}/poi/${pkgVersion}\u001B[0m
+        \u001B[33mmvn:${pkgGroupId}/poi-contrib/${pkgVersion}\u001B[0m
+        \u001B[33mmvn:${pkgGroupId}/poi-scratchpad/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    The Apache POI Project's mission is to create and maintain Java APIs for manipulating various file formats based
+    upon the Office Open XML standards (OOXML) and Microsoft's OLE 2 Compound Document format (OLE2). In short, you can
+    read and write MS Excel files using Java. In addition, you can read and write MS Word and MS PowerPoint files using
+    Java. Apache POI is your Java Excel solution (for Excel 97-2008). We have a complete API for porting other OOXML and
+    OLE2 formats and welcome others to participate.
+
+    OLE2 files include most Microsoft Office files such as XLS, DOC, and PPT as well as MFC serialization API based file
+    formats. The project provides APIs for the OLE2 Filesystem (POIFS) and OLE2 Document Properties (HPSF).
+
+    Office OpenXML Format is the new standards based XML file format found in Microsoft Office 2007 and 2008. This
+    includes XLSX, DOCX and PPTX. The project provides a low level API to support the Open Packaging Conventions using
+    openxml4j.
+
+    For each MS Office application there exists a component module that attempts to provide a common high level Java api
+    to both OLE2 and OOXML document formats. This is most developed for Excel workbooks (SS=HSSF+XSSF). Work is
+    progressing for Word documents (HWPF+XWPF) and PowerPoint presentations (HSLF+XSLF).
+
+    The project has recently added support for Outlook (HSMF). Microsoft opened the specifications to this format in
+    October 2007. We would welcome contributions.
+
+    There are also projects for Visio (HDGF), TNEF (HMEF), and Publisher (HPBF).
+
+    As a general policy we collaborate as much as possible with other projects to provide this functionality.
+    Examples include: Cocoon for which there are serializers for HSSF; Open Office.org with whom we collaborate in
+    documenting the XLS format; and Tika / Lucene, for which we provide format interpretors.
+    When practical, we donate components directly to those projects for POI-enabling them.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://poi.apache.org/\u001B[0m


### PR DESCRIPTION
Added a new module for poi-3.11, and included the
poi-ooxml-schemas which is missing in the poi-3.9 module.

This provides the ability to read microsoft xlsx files (tested)
and in theory all or ther file types supported by poi-ooxml
and poi-ooxml-schemas (untested)
